### PR TITLE
Return non-zero exit code on failing tasks

### DIFF
--- a/.lefthook/quality-assurance.sh
+++ b/.lefthook/quality-assurance.sh
@@ -5,7 +5,8 @@ run_task() {
 		if mise tasks ls | grep --quiet --word-regexp "$1"; then
 			echo "mise-en-place detected. Running '$1'."
 			mise run "$1"
-			return 0
+			EXIT_CODE=$?
+			return $EXIT_CODE # Unquoted to retain the numeric type of the exit code.
 		else
 			echo "'mise.toml' does not define a task named '$1'."
 		fi
@@ -17,7 +18,8 @@ run_task() {
 		if just --summary | grep --quiet --word-regexp "$1"; then
 			echo "Just detected. Running '$1'."
 			just "$1"
-			return 0
+			EXIT_CODE=$?
+			return $EXIT_CODE # Unquoted to retain the numeric type of the exit code.
 		else
 			echo "'justfile' does not define a recipe named '$1'."
 		fi
@@ -30,24 +32,32 @@ run_task() {
 			if [[ -f 'pnpm-lock.yaml' ]]; then
 				echo "pnpm detected. Running '$1'."
 				pnpm run "$1"
+				EXIT_CODE=$?
+				return $EXIT_CODE # Unquoted to retain the numeric type of the exit code.
 
 			# Bun
 			# https://bun.sh
 			elif [[ -f 'bun.lockb' ]]; then
 				echo "Bun detected. Running '$1'."
 				bun run "$1"
+				EXIT_CODE=$?
+				return $EXIT_CODE # Unquoted to retain the numeric type of the exit code.
 
 			# Yarn
 			# https://yarnpkg.com
 			elif [[ -f 'yarn.lock' ]]; then
 				echo "Yarn detected. Running '$1'."
 				yarn run "$1"
+				EXIT_CODE=$?
+				return $EXIT_CODE # Unquoted to retain the numeric type of the exit code.
 
 			# npm
 			# https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager
 			elif [[ -f 'package-lock.json' ]]; then
 				echo "npm detected. Running '$1'."
 				npm run "$1"
+				EXIT_CODE=$?
+				return $EXIT_CODE # Unquoted to retain the numeric type of the exit code.
 
 			else
 				echo "No package manager detected. Skipping '$1'."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ on [Keep a Changelog](https://keepachangelog.com/en/1.1.0), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make failing tasks in `quality-assurance.yml` return a non-zero exit code to
+  prevent the commit or the push operation from happening.
 
 ## [1.1.0] - 2025-01-01
 ### Added


### PR DESCRIPTION
The early function return cancelled the non-zero exit code.