### PR TITLE
Fix compatibility issue on macOS

### DIFF
--- a/.lefthook/quality-assurance.sh
+++ b/.lefthook/quality-assurance.sh
@@ -26,7 +26,7 @@ run_task() {
 	fi
 
 	if [[ -f 'package.json' ]]; then
-		if sed -n '/"scripts": {/,/}/p' 'package.json' | grep --perl-regexp --quiet "\"$1\": \""; then
+		if sed -n '/"scripts": {/,/}/p' 'package.json' | grep --quiet "\"$1\": \""; then
 			# pnpm
             # https://pnpm.io
 			if [[ -f 'pnpm-lock.yaml' ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ on [Keep a Changelog](https://keepachangelog.com/en/1.1.0), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make task detection in `package.json` in `quality-assurance.yml` compatible
+  with macOS by dropping the use of the `--perl-regexp` option in `grep`.
 
 ## [1.1.1] - 2025-04-06
 ### Fixed


### PR DESCRIPTION
The BSD implementation of `grep` used on macOS does not support the `--perl-regexp` option. But it turns out that it isn't necessary in this particular scenario.